### PR TITLE
Puppet removed the symbolize() method in puppet 3.0

### DIFF
--- a/lib/puppet/provider/junos/junos_parent.rb
+++ b/lib/puppet/provider/junos/junos_parent.rb
@@ -89,7 +89,7 @@ class Puppet::Provider::Junos < Puppet::Provider
   
   def self.mk_netdev_resource_methods
     (resource_type.validproperties - [:ensure]).each do |prop|
-      prop_sym = symbolize(prop)
+      prop_sym = Facter.puppetversion.to_i >= 3 ? prop.intern : symbolize(prop)
       define_method(prop_sym) do
         netdev_res_property( prop_sym )
       end


### PR DESCRIPTION
symbolize() was removed in puppet 3. Replacing it with the .intern
method if the puppet version is >= 3.

See also http://projects.puppetlabs.com/issues/16791
