### PR TITLE
Interface properties

### DIFF
--- a/lib/facter/interface_properties.rb
+++ b/lib/facter/interface_properties.rb
@@ -1,0 +1,42 @@
+# Facts: speed_configurable, duplex_configurable
+#
+# Purpose:
+#   Checks if speed and duplex properties of interfaces
+#   are configurable dependening on the productmodel. 
+#
+# Test:
+# # facter -p speed_configurable
+# # false
+#
+# # facter -p duplex_configurable
+# # false
+#
+# Caveats:
+#
+
+Facter.add(:speed_configurable) do 
+   setcode do
+     case Facter.value("productmodel")
+      when /PTX10003-80C|PTX10003-160C/
+         false
+      when /QFX10003-80C|QFX10003-160C/
+         false
+      else
+         true
+     end
+   end
+end
+
+
+Facter.add(:duplex_configurable) do 
+   setcode do
+     case Facter.value("productmodel")
+      when /PTX10003-80C|PTX10003-160C/
+         false
+      when /QFX10003-80C|QFX10003-160C/
+         false
+      else
+         true
+     end
+   end
+end

--- a/lib/facter/junos.rb
+++ b/lib/facter/junos.rb
@@ -1,0 +1,59 @@
+
+  ### -----------------------------------------------------------------------------
+  ### junos_personality
+  ### -----------------------------------------------------------------------------
+
+  Facter.add(:junos_personality) do
+    setcode do
+       case Facter.value("productmodel")
+       when /^(ex)|(qfx)|(pvi-model)/
+          "JUNOS_switch"
+       when /^srx(\d){4}/
+          "JUNOS_SRX_HE"
+       when /^srx(\d){3}/
+          "JUNOS_SRX_branch"
+       when /^junosv-firefly/
+	  "JUNOS_SRX_branch"
+       when /^mx|^vmx/
+          "JUNOS_MX"
+       when /PTX/
+          "JUNOS_switch"
+       end
+    end
+  end
+
+  ### -----------------------------------------------------------------------------
+  ### junos_ifd_style [ 'classis', 'switch' ]
+  ### -----------------------------------------------------------------------------
+
+  Facter.add(:junos_ifd_style) do
+    confine :junos_personality => :JUNOS_switch
+    setcode { "switch" }
+  end
+
+  Facter.add(:junos_ifd_style) do
+    setcode { "classic" }
+  end
+
+  ### -----------------------------------------------------------------------------
+  ### junos_switch_style [ 'vlan', 'bridge_domain', 'vlan_l2ng', 'none' ]
+  ### -----------------------------------------------------------------------------
+
+  Facter.add(:junos_switch_style) do
+    confine :junos_personality => [:JUNOS_switch, :JUNOS_SRX_branch]  
+    setcode do
+      case Facter.value("productmodel")
+      when /^(ex9)|(ex43)|(pvi-model)/
+        "vlan_l2ng"
+      when /^(qfx5)|(qfx3)/
+        Facter.value("kernelmajversion")[0..3].to_f >= 13.2 ? "vlan_l2ng" : "vlan"
+      else
+        "vlan"
+      end
+    end
+  end
+
+  Facter.add(:junos_switch_style) do
+    confine :junos_personality => [:JUNOS_MX, :JUNOS_SRX_HE]  
+    setcode { "bridge_domain" }
+  end

--- a/lib/facter/productmodel.rb
+++ b/lib/facter/productmodel.rb
@@ -1,0 +1,30 @@
+# Fact: productmodel
+#
+# Purpose:
+#   Returns the product model of the system.
+#
+# Test:
+# # facter -p productmodel
+# JNP10003-160C [PTX10003-160C]
+#
+# Caveats:
+#
+
+Facter.add(:productmodel) do
+  setcode do
+     require 'net/netconf/jnpr/ioproc'
+     ndev = Netconf::IOProc.new
+     ndev.open
+     inv_info = ndev.rpc.get_chassis_inventory
+     errs = inv_info.xpath('//output')[0]
+
+     if errs and errs.text.include? "This command can only be used on the master routing engine"
+        raise Junos::Ez::NoProviderError, "Puppet can only be used on master routing engine !!"
+     end
+
+     chassis = inv_info.xpath('chassis')
+     ndev.close
+     #Return chassis description which contains productmodel. 
+     chassis.xpath('description').text
+  end
+end

--- a/lib/puppet/provider/junos/junos_interface.rb
+++ b/lib/puppet/provider/junos/junos_interface.rb
@@ -50,27 +50,28 @@ class Puppet::Provider::Junos::Interface < Puppet::Provider::Junos
     @ndev_res[:admin] = ifd.xpath('disable').empty? ? :up : :down
     @ndev_res[:mtu] = (mtu = ifd.xpath('mtu')[0]).nil? ? -1 : mtu.text.to_i
     
-    phy_options = ifd.xpath('ether-options')
+    if $speed_configurable || $duplex_configurable
+      phy_options = ifd.xpath('ether-options')
     
-    if phy_options.empty?
-      @ndev_res[:speed] = :auto
-      @ndev_res[:duplex] = :auto
-    else 
-      
-      @ndev_res[:duplex] = case phy_options.xpath('link-mode').text.chomp
-        when 'full-duplex' then :full
-        when 'half-duplex' then :half
-        else :auto
-      end
-      
-      if speed = phy_options.xpath('speed')[0]
-        @ndev_res[:speed] = speed_from_junos( speed.first_element_child.name )
-      else
+      if phy_options.empty?
         @ndev_res[:speed] = :auto
+        @ndev_res[:duplex] = :auto
+      else
+      
+        @ndev_res[:duplex] = case phy_options.xpath('link-mode').text.chomp
+          when 'full-duplex' then :full
+          when 'half-duplex' then :half
+          else :auto
+        end
+      
+        if speed = phy_options.xpath('speed')[0]
+          @ndev_res[:speed] = speed_from_junos( speed.first_element_child.name )
+        else
+          @ndev_res[:speed] = :auto
+        end
       end
-    end
-    
-    return true     
+    end   #### $speed_configurable || $duplex_configurable
+    return true
   end
 
   ### ---------------------------------------------------------------
@@ -137,33 +138,37 @@ class Puppet::Provider::Junos::Interface < Puppet::Provider::Junos
   end
   
   def xml_change_speed( xml )         
-    xml.send(:'ether-options') {
-      xml.speed {
-        if resource[:speed] == :auto
-          if not @ndev_res.is_new?
-            jval = speed_to_junos( @ndev_res[:speed] )
-            xml.send( jval, Netconf::JunosConfig::DELETE )
+    if $speed_configurable
+      xml.send(:'ether-options') {
+        xml.speed {
+          if resource[:speed] == :auto
+            if not @ndev_res.is_new?
+              jval = speed_to_junos( @ndev_res[:speed] )
+              xml.send( jval, Netconf::JunosConfig::DELETE )
+            end
+          else
+            xml.send( speed_to_junos( resource[:speed] ))
           end
-        else
-          xml.send( speed_to_junos( resource[:speed] ))
-        end
+        }
       }
-    }    
+    end
   end
   
   def xml_change_duplex( xml )     
-    xml.send(:'ether-options') {
-      if resource[:duplex] == :auto
-        unless @ndev_res.is_new?
-          xml.send( :'link-mode', Netconf::JunosConfig::DELETE )
+    if $duplex_configurable
+      xml.send(:'ether-options') {
+        if resource[:duplex] == :auto
+          unless @ndev_res.is_new?
+            xml.send( :'link-mode', Netconf::JunosConfig::DELETE )
+          end
+        else
+          xml.send( :'link-mode', case resource[:duplex]
+             when :full then 'full-duplex'
+             when :half then 'half-duplex'
+          end )
         end
-      else
-        xml.send( :'link-mode', case resource[:duplex]
-           when :full then 'full-duplex'
-           when :half then 'half-duplex'
-        end )
-      end
-    }    
+      }
+    end
   end
-  
+
 end


### PR DESCRIPTION
The interface properties, speed and duplex mode, are not configurable on certain platforms.
1) Introduced a facts file to enable/disable configurations.
2) Modified interface code to check with facts before configuring these
properties.