### PR TITLE
Fixes for netdev_lag resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,9 @@
   - Issue #20 Issue while configuring LAG on 15.2 junos-x image
 * Fixed puppet lint issues
 * Upgrade to a stable version 2.0.2
+
+### 2019-02-27
+* Bug fix:
+  - Issue with netdev_lag creation and deletion - interfaces arriving as array
+    entries changed to look like normal interfaces to netconf.
+* Upgrade to 2.0.5

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'juniper-netdev_stdlib_junos'
-version '2.0.2'
+version '2.0.5'
 source 'https://github.com/Juniper/puppet-netdev-stdlib-junos'
 author 'Jeremy Schulman, Ganesh Nalawade, Juniper Networks'
 license 'See LICENSE file'


### PR DESCRIPTION
This commit fixes 2 issues:
1) Invalid interface type for netdev_lag - This was happening because
   the interface name is passed as a single-element array. Netconf expects an interface name string.  This patch extracts the string from the array and constructs an XML element out of it. Fixed in set_cookie_links function.
2) When existing interfaces of a lag were deleted or new ones added in
   the puppet manifest file, the update was not happening correctly.
   This was due to an incorrect order of propagation of update. Delete must happen before adding. This was fixed in xml_change_links function.

Apart from these 2 fixes, a new function, trim_ifd(str) was added.
This function trims the bracket and double quotes from stringized array
objects.