### PR TITLE
Adds ability for puppet to work from a container environment for Junos-specific modules

### DIFF
--- a/lib/facter/container.rb
+++ b/lib/facter/container.rb
@@ -1,0 +1,23 @@
+# Fact: container
+#
+# Purpose:
+#   Returns the container type.
+#
+# Test:
+# # facter -p container
+# docker
+#
+# Caveats:
+#
+
+Facter.add(:container) do
+  setcode do
+    query = ":/docker"
+    arr = File.readlines("/proc/1/cgroup").grep /#{query}/i
+    if arr.any?
+       "docker"
+    else
+       false
+    end
+  end
+end

--- a/lib/facter/productmodel.rb
+++ b/lib/facter/productmodel.rb
@@ -10,21 +10,35 @@
 # Caveats:
 #
 
+is_docker = (Facter.value(:container) == "docker")
+
 Facter.add(:productmodel) do
   setcode do
-     require 'net/netconf/jnpr/ioproc'
-     ndev = Netconf::IOProc.new
-     ndev.open
-     inv_info = ndev.rpc.get_chassis_inventory
-     errs = inv_info.xpath('//output')[0]
 
-     if errs and errs.text.include? "This command can only be used on the master routing engine"
-        raise Junos::Ez::NoProviderError, "Puppet can only be used on master routing engine !!"
-     end
+    # In case of docker container, open a NETCONF/SSH session
+    if is_docker
+      require 'net/netconf/jnpr'
+      # NETCONF_USER refers to the login username configured for puppet operations
+      login = { target: 'localhost', username: ENV['NETCONF_USER'] }
+      @netconf = Netconf::SSH.new(login)
+    # Else, open an IOProc session
+    else
+      require 'net/netconf/jnpr/ioproc'
+      @netconf = Netconf::IOProc.new
+    end
+    @netconf.open
+    inv_info = @netconf.rpc.get_chassis_inventory
+    errs = inv_info.xpath('//output')[0]
 
-     chassis = inv_info.xpath('chassis')
-     ndev.close
-     #Return chassis description which contains productmodel. 
-     chassis.xpath('description').text
+    if errs && errs.text.include?('This command can only be used on the
+                        master routing engine')
+      raise Junos::Ez::NoProviderError, 'Puppet can only be used on
+                        master routing engine !!'
+    end
+
+    chassis = inv_info.xpath('chassis')
+    @netconf.close
+    # Return chassis description which contains productmodel.
+    chassis.xpath('description').text
   end
 end


### PR DESCRIPTION
## Summary

The pull request allows the container to operate from a container environment, it uses `Netconf::SSH` method to authenticate to the target device.

**_Requirements_**:
- A passwordless authentication should be setup b/w target and container.
- The user that is configured to perform Puppet operations should be exported as an environment variable. **Command**: `export NETCONF_USER=puppet`