### PR TITLE
Added port number to login arguments

### DIFF
--- a/lib/facter/productmodel.rb
+++ b/lib/facter/productmodel.rb
@@ -19,7 +19,7 @@ Facter.add(:productmodel) do
     if is_docker
       require 'net/netconf/jnpr'
       # NETCONF_USER refers to the login username configured for puppet operations
-      login = { target: 'localhost', username: ENV['NETCONF_USER'] }
+      login = { target: 'localhost', username: ENV['NETCONF_USER'], port:22 }
       @netconf = Netconf::SSH.new(login)
     # Else, open an IOProc session
     else

--- a/lib/facter/productmodel.rb
+++ b/lib/facter/productmodel.rb
@@ -19,7 +19,8 @@ Facter.add(:productmodel) do
     if is_docker
       require 'net/netconf/jnpr'
       # NETCONF_USER refers to the login username configured for puppet operations
-      login = { target: 'localhost', username: ENV['NETCONF_USER'], port:22 }
+      login = { target: 'localhost', username: ENV['NETCONF_USER'],
+                port: ENV['NETCONF_PORT'] ? ENV['NETCONF_PORT'].to_i : 22 }
       @netconf = Netconf::SSH.new(login)
     # Else, open an IOProc session
     else

--- a/lib/puppet/provider/junos/junos_netdev_device.rb
+++ b/lib/puppet/provider/junos/junos_netdev_device.rb
@@ -23,7 +23,8 @@ module NetdevJunos
 
       if is_docker
         # NETCONF_USER refers to the login username configured for puppet operations
-        login = { target: 'localhost', username: ENV['NETCONF_USER'], port:22 }
+        login = { target: 'localhost', username: ENV['NETCONF_USER'],
+                  port: ENV['NETCONF_PORT'] ? ENV['NETCONF_PORT'].to_i : 22 }
         @netconf = Netconf::SSH.new(login)
         NetdevJunos::Log.debug "Opening a SSH connection from docker container: #{is_docker}"
       else

--- a/lib/puppet/provider/junos/junos_netdev_device.rb
+++ b/lib/puppet/provider/junos/junos_netdev_device.rb
@@ -23,7 +23,7 @@ module NetdevJunos
 
       if is_docker
         # NETCONF_USER refers to the login username configured for puppet operations
-        login = { target: 'localhost', username: ENV['NETCONF_USER'] }
+        login = { target: 'localhost', username: ENV['NETCONF_USER'], port:22 }
         @netconf = Netconf::SSH.new(login)
         NetdevJunos::Log.debug "Opening a SSH connection from docker container: #{is_docker}"
       else


### PR DESCRIPTION
Current implementation fails with the below error using containers:

```
Could not retrieve fact='productmodel', resolution='<anonymous>': Authentication failed for user puppet@localhost
```

Adding port number seems to fix the issue for now. Don't exactly know where the root cause is.
Will try to inquire on this further and update the thread.

Verified NETCONF session from container to host:

```
root@xxxx:/puppet-agent# ssh puppet@localhost -s netconf
<!-- No zombies were killed during the creation of this user interface -->
<!-- user puppet, class puppet -->
<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <capabilities>
    <capability>urn:ietf:params:netconf:base:1.0</capability>
    <capability>urn:ietf:params:netconf:capability:candidate:1.0</capability>
    <capability>urn:ietf:params:netconf:capability:confirmed-commit:1.0</capability>
    <capability>urn:ietf:params:netconf:capability:validate:1.0</capability>
    <capability>urn:ietf:params:netconf:capability:url:1.0?scheme=http,ftp,file</capability>
    <capability>urn:ietf:params:xml:ns:netconf:base:1.0</capability>
    <capability>urn:ietf:params:xml:ns:netconf:capability:candidate:1.0</capability>
    <capability>urn:ietf:params:xml:ns:netconf:capability:confirmed-commit:1.0</capability>
    <capability>urn:ietf:params:xml:ns:netconf:capability:validate:1.0</capability>
    <capability>urn:ietf:params:xml:ns:netconf:capability:url:1.0?scheme=http,ftp,file</capability>
    <capability>urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring</capability>
    <capability>http://xml.juniper.net/netconf/junos/1.0</capability>
    <capability>http://xml.juniper.net/dmi/system/1.0</capability>
  </capabilities>
  <session-id>5221</session-id>
</hello>
]]>]]>
```