### PR TITLE
Changed logic to calculate is_container fact 

### DIFF
--- a/lib/facter/container.rb
+++ b/lib/facter/container.rb
@@ -12,7 +12,7 @@
 
 Facter.add(:container) do
   setcode do
-    query = ":/docker"
+    query = "/docker"
     arr = File.readlines("/proc/1/cgroup").grep /#{query}/i
     if arr.any?
        "docker"


### PR DESCRIPTION
The query string will verify for `/docker` instead of `:/docker`.

Will verify with Mrinal about the most accurate way to determine if the process is running in a container.