### PR TITLE
Fixes "odd number list for Hash" error in Junos

### DIFF
--- a/lib/facter/productmodel.rb
+++ b/lib/facter/productmodel.rb
@@ -19,7 +19,8 @@ Facter.add(:productmodel) do
     if is_docker
       require 'net/netconf/jnpr'
       # NETCONF_USER refers to the login username configured for puppet operations
-      login = { target: 'localhost', username: ENV['NETCONF_USER'] }
+      login = { :target => 'localhost', :username => ENV['NETCONF_USER'],
+                :port => ENV['NETCONF_PORT'] ? ENV['NETCONF_PORT'].to_i : 22 }
       @netconf = Netconf::SSH.new(login)
     # Else, open an IOProc session
     else

--- a/lib/puppet/provider/junos/junos_netdev_device.rb
+++ b/lib/puppet/provider/junos/junos_netdev_device.rb
@@ -23,7 +23,8 @@ module NetdevJunos
 
       if is_docker
         # NETCONF_USER refers to the login username configured for puppet operations
-        login = { target: 'localhost', username: ENV['NETCONF_USER'] }
+        login = { :target => 'localhost', :username => ENV['NETCONF_USER'],
+                  :port => ENV['NETCONF_PORT'] ? ENV['NETCONF_PORT'].to_i : 22 }
         @netconf = Netconf::SSH.new(login)
         NetdevJunos::Log.debug "Opening a SSH connection from docker container: #{is_docker}"
       else


### PR DESCRIPTION
## Root cause

There is a syntax difference in declaring a dict b/w ruby 1.8.7 and ruby 1.9. Please refer https://stackoverflow.com/questions/8014090/odd-number-list-for-hash.

 