### PR TITLE
Enabled case-insensitive comparison of QFX Product Models.

### DIFF
--- a/lib/facter/junos.rb
+++ b/lib/facter/junos.rb
@@ -6,7 +6,7 @@
   Facter.add(:junos_personality) do
     setcode do
        case Facter.value("productmodel")
-       when /^(ex)|(qfx)|(pvi-model)/
+       when /^(ex)|(qfx)|(pvi-model)/i
           "JUNOS_switch"
        when /^srx(\d){4}/
           "JUNOS_SRX_HE"


### PR DESCRIPTION
Certain QFX product models are in UPPERCASE. Since existing regex matches only matched lowercase product models, it resulted in lack of personality for the product. Providers are confined to personalities. Lack of personalities makes the provider unsuitable for the product thereby preventing puppet client from making appropriate config changes on the box. 